### PR TITLE
js -> ls

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "version": "0.0.7",
   "main": "lib/index.js",
   "bin": {
-    "pgrest": "bin/cmd.js"
+    "pgrest": "bin/cmd.ls"
   },
   "repository": {
     "type": "git",

--- a/package.ls
+++ b/package.ls
@@ -7,7 +7,7 @@ description: 'enable REST in postgres'
 version: '0.0.7'
 main: \lib/index.js
 bin:
-  pgrest: 'bin/cmd.js'
+  pgrest: 'bin/cmd.ls'
 repository:
   type: 'git'
   url: 'git://github.com/clkao/pgrest.git'


### PR DESCRIPTION
cmd.js should be generated by lsc.
npm tries to chmod to cmd.js before we create it. so we will get
this error message.

```
npm ERR! Error: ENOENT, chmod
'/path-to/api.ly/node_modules/pgrest/bin/cmd.js'
```

since we already chmod manually (by scripts@package.json), we don't
need this instruction actually. workaround it!
