### PR TITLE
Change test cases timeout to 10000ms

### DIFF
--- a/test/array.ls
+++ b/test/array.ls
@@ -4,6 +4,7 @@ expect = (require \chai).expect
 
 var plx, _plx
 describe 'Array', ->
+  this.timeout 10000ms
   beforeEach (done) ->
     _plx <- mk-pgrest-fortest!
     plx := _plx

--- a/test/cli.ls
+++ b/test/cli.ls
@@ -5,6 +5,7 @@ expect = (require \chai).expect
 require! <[supertest express]>
 var pgrest, app
 describe 'CLI', ->
+  this.timeout 10000ms
   beforeEach (done) ->
     pgrest := require \..
     pgrest.should.be.ok

--- a/test/insert.ls
+++ b/test/insert.ls
@@ -3,6 +3,7 @@ should = (require \chai).should!
 
 var _plx, plx
 describe 'Insert', ->
+  this.timeout 10000ms
   beforeEach (done) ->
     _plx <- mk-pgrest-fortest!
     plx := _plx

--- a/test/routes.ls
+++ b/test/routes.ls
@@ -9,6 +9,7 @@ pgrest = require \..
 boot = {}
 
 describe 'Routing', ->
+  this.timeout 10000ms
   beforeEach (done) ->
     _plx <- mk-pgrest-fortest!
     plx := _plx

--- a/test/select.ls
+++ b/test/select.ls
@@ -3,6 +3,7 @@ should = (require \chai).should!
 
 var _plx, plx
 describe 'Select', ->
+  this.timeout 10000ms
   beforeEach (done) ->
     _plx <- mk-pgrest-fortest!
     plx := _plx

--- a/test/upsert.ls
+++ b/test/upsert.ls
@@ -4,6 +4,7 @@ expect = (require \chai).expect
 
 var _plx, plx
 describe 'Upsert', ->
+  this.timeout 10000ms
   beforeEach (done) ->
     _plx <- mk-pgrest-fortest!
     plx := _plx


### PR DESCRIPTION
The default 2000ms timeout seem to be too short. It is easily to fail due to timeout.
