### PR TITLE
fix TypeError when deleting a collection

### DIFF
--- a/src/routes.ls
+++ b/src/routes.ls
@@ -5,7 +5,7 @@ export function route (path, fn)
     return resp.send 200 if req.method is \OPTION
     resp.setHeader \Content-Type 'application/json; charset=UTF-8'
     done = -> switch typeof it
-      | \number => resp.send it it
+      | \number => resp.send it
       | \object => resp.send 200 JSON.stringify it
       | \string => resp.send "#it"
     handle-error = ->


### PR DESCRIPTION
pgrest will crash with a TypeError when received a DELETE request on a collection

```
% curl -H 'Content-Type: application/json' -X DELETE http://localhost:3000/collections/foo

.../pgrest/node_modules/plv8x/node_modules/tmp/lib/tmp.js:261
  throw err;
        ^
TypeError: number is not a function
    at done (.../MyProject/pgrest/lib/routes.js:14:26)
    at .../MyProject/pgrest/lib/routes.js:59:18
    at null.callback (.../MyProject/pgrest/lib/index.js:52:49)
    at NativeQuery.handleReadyForQuery (.../MyProject/pgrest/node_modules/plv8x/node_modules/pg/lib/native/query.js:77:10)
    at Connection.<anonymous> (.../MyProject/pgrest/node_modules/plv8x/node_modules/pg/lib/native/index.js:236:33)
    at Connection.EventEmitter.emit (events.js:92:17)
```
